### PR TITLE
Allow routes to match the rails port with or without the trailing path separator

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+apt-get update;
+
 apt-get install -y git build-essential automake autoconf libtool;
 
 apt-get install -y libxml2-dev libpqxx-dev libfcgi-dev \

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -309,6 +309,9 @@ handler_ptr_t route_resource(request &req, const string &path,
   list<string> path_components;
   al::split(path_components, resource.first, al::is_any_of("/"));
 
+  if (path_components.rbegin()->compare("") == 0)
+    path_components.pop_back();
+
   handler_ptr_t hptr(r->match(path_components, req));
 
   // if the pointer points at something, then the path was found. otherwise,

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -308,7 +308,9 @@ handler_ptr_t route_resource(request &req, const string &path,
   // split the URL into bits to be matched.
   list<string> path_components;
   al::split(path_components, resource.first, al::is_any_of("/"));
-
+  // remove empty trailing components to allow for "/api/0.6/changeset/create/"
+  // like the rails port instead on only allowing  "/api/0.6/changeset/create"
+  // which fails on the out of the box rails port
   if (path_components.rbegin()->compare("") == 0)
     path_components.pop_back();
 


### PR DESCRIPTION
In testing with a vagrant setup, I found that I needed to run `apt-get update` during provisioning for it to work successfully.
Removed empty trailing components to allow for URLs like the rails port with the trailing `/` path separator:
```
/api/0.6/changeset/create/
```
as opposed to only allowing
```
/api/0.6/changeset/create
```
which causes the "out of the box" rails port to fail on the same call.